### PR TITLE
(SIMP-58) Update to fix rsyslog typos

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -138,13 +138,13 @@ class apache::conf (
 
   if $enable_logging or hiera('use_simp_logging',false) {
     include '::rsyslog'
-    rsyslog::rule::local { '10apache_error':
-      rule            => 'if ($programname == \'httpd\' and $syslogseverity-text == \'err\') then',
+    rsyslog::rule::local { '10_apache_error':
+      rule            => 'if ($programname == "httpd" and $syslogseverity-text == "err") then',
       target_log_file => "${rsyslog_target}/error_log",
       stop_processing => true
     }
-    rsyslog::rule::local { '10apache_access':
-      rule            => 'if ($programname == \'httpd\') then',
+    rsyslog::rule::local { '10_apache_access':
+      rule            => 'if ($programname == "httpd") then',
       target_log_file => "${rsyslog_target}/access_log",
       stop_processing => true
     }


### PR DESCRIPTION
Rsyslog rules can only contain double quotes.

SIMP-58 #comment Rsyslog rules must have double quotes.

Change-Id: If042297480d38fe52262e4879e535e2087f132fc