### PR TITLE
(SIMP-611) Updated from 'lsb' to 'os' facts

### DIFF
--- a/build/pupmod-apache.spec
+++ b/build/pupmod-apache.spec
@@ -1,7 +1,7 @@
 Summary: Apache Puppet Module
 Name: pupmod-apache
 Version: 4.1.0
-Release: 17
+Release: 18
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -21,7 +21,7 @@ Buildarch: noarch
 Requires: simp-bootstrap >= 4.2.0
 Obsoletes: pupmod-apache-test
 
-Prefix: /etc/puppet/environments/simp/modules
+Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
 %description
 This Puppet module provides the capability to configure Apache and component
@@ -64,6 +64,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Thu Nov 12 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-18
+- Updated to switch from 'lsb*' facts to 'operatingsystem*' facts for
+  environments that don't install the LSB packages.
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-17
 - migration to simplib and simpcat (lib/ only)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class apache (
   }
 
   if $::operatingsystem in ['RedHat','CentOS'] {
-    if (versioncmp($::lsbmajdistrelease,'7') >= 0) {
+    if (versioncmp($::operatingsystemmajrelease,'7') >= 0) {
       $apache_homedir = '/usr/share/httpd'
 
       package { 'mod_ldap':

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -8,7 +8,7 @@ describe 'apache::conf' do
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
     :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
+    :operatingsystemmajrelease => '7',
     :apache_version => '2.4',
     :grub_version => '2.0~beta',
     :uid_min => '500'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,7 +8,7 @@ describe 'apache' do
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
     :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
+    :operatingsystemmajrelease => '7',
     :apache_version => '2.4',
     :grub_version => '2.0~beta',
     :uid_min => '500'

--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -8,7 +8,7 @@ describe 'apache::ssl' do
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
     :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
+    :operatingsystemmajrelease => '7',
     :apache_version => '2.4',
     :grub_version => '2.0~beta',
     :uid_min => '500'

--- a/spec/defines/add_site_spec.rb
+++ b/spec/defines/add_site_spec.rb
@@ -7,7 +7,7 @@ describe 'apache::add_site' do
     :interfaces => 'lo',
     :ipaddress_lo => '127.0.0.1',
     :operatingsystem => 'RedHat',
-    :lsbmajdistrelease => '7',
+    :operatingsystemmajrelease => '7',
     :apache_version => '2.4',
     :grub_version => '2.0~beta',
     :uid_min => '500',

--- a/templates/etc/httpd/conf/httpd.conf.erb
+++ b/templates/etc/httpd/conf/httpd.conf.erb
@@ -60,7 +60,7 @@ MaxRequestsPerChild  <%= @worker_maxrequestsperchild %>
 Listen <%= scope.function_bracketize([l]) %>
 <% end -%>
 
-<% if (['RedHat','CentOS'].include?(@operatingsystem) ) and scope.function_versioncmp([@lsbmajdistrelease,'7']) < 0 then -%>
+<% if (['RedHat','CentOS'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'7']) < 0 then -%>
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule include_module modules/mod_include.so
@@ -90,7 +90,7 @@ LoadModule proxy_module modules/mod_proxy.so
 LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_connect_module modules/mod_proxy_connect.so
-<%   if ( ['RedHat','CentOS'].include?(@operatingsystem) ) and scope.function_versioncmp([@lsbmajdistrelease,'6']) < 0 then -%>
+<%   if ( ['RedHat','CentOS'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'6']) < 0 then -%>
 LoadModule cache_module modules/mod_cache.so
 LoadModule file_cache_module modules/mod_file_cache.so
 LoadModule disk_cache_module modules/mod_disk_cache.so
@@ -98,7 +98,7 @@ LoadModule mem_cache_module modules/mod_mem_cache.so
 <%   end -%>
 LoadModule suexec_module modules/mod_suexec.so
 LoadModule cgi_module modules/mod_cgi.so
-<%   if ( ['RedHat','CentOS'].include?(@operatingsystem) ) and scope.function_versioncmp([@lsbmajdistrelease,'4']) > 0 then -%>
+<%   if ( ['RedHat','CentOS'].include?(@operatingsystem) ) and scope.function_versioncmp([@operatingsystemmajrelease,'4']) > 0 then -%>
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_alias_module modules/mod_authn_alias.so


### PR DESCRIPTION
Updated to the 'lsb*' facts to the 'operatingsystem*' facts to ensure
functionality in environments that do not install the LSB packages.

SIMP-611 #comment Compatibility update