### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*.sw?
+.yardoc
+dist
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,90 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
-rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+before_script:
+  - bundle
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
+  - bundle exec rake test
+notifications:
+  email: false
+rvm:
+  - 1.8.7
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,52 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem "rake"
+  gem 'puppet', puppetversion
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
+    gem 'simp-rake-helpers'
+  end
+end
+
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,28 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
-  PuppetLint.configuration.send("disable_selector_inside_resource")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-apache.spec
+++ b/build/pupmod-apache.spec
@@ -1,13 +1,12 @@
 Summary: Apache Puppet Module
 Name: pupmod-apache
 Version: 4.1.0
-Release: 19
+Release: 20
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-auditd >= 4.1.0-2
-Requires: pupmod-common >= 4.1.0-5
 Requires: pupmod-simplib >= 1.0.0-0
 Requires: pupmod-simpcat >= 4.0.0-0
 Requires: pupmod-iptables >= 4.1.0-3
@@ -64,6 +63,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Tue Jan 26 2016 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-20
+- Normalized common static module assets
+
 * Thu Jan 07 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-19
 - Updated to correct some ordering issues.
 

--- a/manifests/add_site.pp
+++ b/manifests/add_site.pp
@@ -20,16 +20,20 @@
 define apache::add_site (
   $content = 'base'
 ) {
+  validate_string( $content )
+
   include 'apache'
+
+  $_content = $content ? {
+    'base'  => template("apache/etc/httpd/conf.d/${name}.conf.erb"),
+    default => $content
+  }
 
   file { "/etc/httpd/conf.d/${name}.conf":
     owner   => hiera('apache::conf::group','root'),
     group   => hiera('apache::conf::group','apache'),
     mode    => '0640',
-    content => $content ? {
-      'base'  => template("apache/etc/httpd/conf.d/${name}.conf.erb"),
-      default => $content
-    },
+    content => $_content,
     notify  => Service['httpd']
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,11 @@ class apache (
   $rsync_web_root = true,
   $ssl = true
 ) {
+  validate_absolute_path($data_dir)
+  validate_bool($ssl)
+  validate_string($rsync_server)
+  validate_integer($rsync_timeout)
+  validate_bool($rsync_web_root)
 
   include '::apache::install'
   include '::apache::conf'
@@ -63,6 +68,12 @@ class apache (
   }
   else {
     $apache_homedir = '/var/www'
+  }
+
+
+  $_modules_target = $::hardwaremodel ? {
+    'x86_64' => '/usr/lib64/httpd/modules',
+    default  => '/usr/lib/httpd/modules'
   }
 
   file { $data_dir:
@@ -97,10 +108,7 @@ class apache (
 
   file { '/etc/httpd/modules':
     ensure => 'symlink',
-    target => $::hardwaremodel ? {
-      'x86_64' => '/usr/lib64/httpd/modules',
-      default  => '/usr/lib/httpd/modules'
-    },
+    target =>  $_modules_target,
     force  => true
   }
 
@@ -119,10 +127,7 @@ class apache (
 
   file { 'httpd_modules':
     ensure => 'directory',
-    path   => $::hardwaremodel ? {
-      'x86_64' => '/usr/lib64/httpd/modules',
-      default  => '/usr/lib/httpd/modules'
-    },
+    path   => $_modules_target,
     owner  => 'root',
     group  => 'root',
     mode   => '0755',
@@ -185,9 +190,4 @@ class apache (
     uid        => '48',
     require    => Group['apache']
   }
-
-  validate_absolute_path($data_dir)
-  validate_bool($ssl)
-  validate_integer($rsync_timeout)
-  validate_bool($rsync_web_root)
 }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -66,6 +66,16 @@ class apache::ssl (
   $cert_source = '',
   $use_simp_pki = true
 ) {
+  validate_array($ssl_cipher_suite)
+  validate_array($ssl_protocols)
+  validate_array_member($ssl_honor_cipher_order,['on','off'])
+  validate_integer($sslverifydepth)
+  validate_absolute_path($sslcacertificatepath)
+  validate_absolute_path($sslcertificatefile)
+  validate_absolute_path($sslcertificatekeyfile)
+  validate_bool($enable_default_vhost)
+  validate_bool($enable_iptables)
+  validate_bool($use_simp_pki)
   include '::apache'
 
   file { '/etc/httpd/conf.d/ssl.conf':
@@ -104,15 +114,4 @@ class apache::ssl (
       notify => Service['httpd']
     }
   }
-
-  validate_array($ssl_cipher_suite)
-  validate_array($ssl_protocols)
-  validate_array_member($ssl_honor_cipher_order,['on','off'])
-  validate_integer($sslverifydepth)
-  validate_absolute_path($sslcacertificatepath)
-  validate_absolute_path($sslcertificatefile)
-  validate_absolute_path($sslcertificatekeyfile)
-  validate_bool($enable_default_vhost)
-  validate_bool($enable_iptables)
-  validate_bool($use_simp_pki)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,65 @@
+{
+  "name":    "simp-apache",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "configure SIMP apache  & copmonent sites (NOTE: legacy, conflicts with puppetlabs-apache)",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-apache",
+  "project_page": "https://github.com/simp/pupmod-simp-apache",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "apache" ],
+  "dependencies": [
+    {
+      "name": "simp-iptables",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-auditd",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    },
+    {
+      "name": "simp-simpcat",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "simp-logrotate",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "simp-pki",
+      "version_requirement": ">= 3.0.0"
+    },
+    {
+      "name": "simp-rsync",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "simp-rsyslog",
+      "version_requirement": ">= 4.1.0"
+    },
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.1.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -15,31 +15,31 @@ describe 'apache::conf' do
   }
   let(:facts){base_facts}
 
-  it { should compile.with_all_deps }
-  it { should create_class('apache::conf') }
-  it { should_not create_iptables__add_tcp_stateful_listen('allow_http') }
+  it { is_expected.to compile.with_all_deps }
+  it { is_expected.to create_class('apache::conf') }
+  it { is_expected.not_to create_iptables__add_tcp_stateful_listen('allow_http') }
 # Once the SIMP globals change for SIMPv6, these will actually be the defaults.
 #  it { should_not create_rsyslog__rule__local('10apache_error') }
 #  it { should_not create_rsyslog__rule__local('10apache_access') }
-  it { should create_rsyslog__rule__local('10apache_error') }
-  it { should create_rsyslog__rule__local('10apache_access') }
+  it { is_expected.to create_rsyslog__rule__local('10apache_error') }
+  it { is_expected.to create_rsyslog__rule__local('10apache_access') }
 
   context 'enable_iptables' do
     let(:params){{ 'enable_iptables' => true }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('iptables') }
-    it { should create_class('apache::conf') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_http') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('iptables') }
+    it { is_expected.to create_class('apache::conf') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_http') }
   end
 
   context 'enable_logging' do
     let(:params){{ 'enable_logging' => true }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('apache::conf') }
-    it { should create_class('rsyslog') }
-    it { should create_rsyslog__rule__local('10apache_error') }
-    it { should create_rsyslog__rule__local('10apache_access') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache::conf') }
+    it { is_expected.to create_class('rsyslog') }
+    it { is_expected.to create_rsyslog__rule__local('10apache_error') }
+    it { is_expected.to create_rsyslog__rule__local('10apache_access') }
   end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,33 +16,33 @@ describe 'apache' do
   let(:facts){base_facts}
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::conf') }
-    it { should create_class('apache::ssl') }
-    it { should create_rsync('site') }
-    it { should create_selboolean('httpd_can_network_connect') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::conf') }
+    it { is_expected.to create_class('apache::ssl') }
+    it { is_expected.to create_rsync('site') }
+    it { is_expected.to create_selboolean('httpd_can_network_connect') }
   end
 
   context 'no_rsync_web_root' do
     let(:params){{ :rsync_web_root => false }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::conf') }
-    it { should create_class('apache::ssl') }
-    it { should_not create_rsync('site') }
-    it { should create_selboolean('httpd_can_network_connect') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::conf') }
+    it { is_expected.to create_class('apache::ssl') }
+    it { is_expected.not_to create_rsync('site') }
+    it { is_expected.to create_selboolean('httpd_can_network_connect') }
   end
 
   context 'no_ssl' do
     let(:params){{ :ssl => false }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::conf') }
-    it { should_not create_class('apache::ssl') }
-    it { should create_rsync('site') }
-    it { should create_selboolean('httpd_can_network_connect') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::conf') }
+    it { is_expected.not_to create_class('apache::ssl') }
+    it { is_expected.to create_rsync('site') }
+    it { is_expected.to create_selboolean('httpd_can_network_connect') }
   end
 end

--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -16,35 +16,35 @@ describe 'apache::ssl' do
   let(:facts){base_facts}
 
   context 'base' do
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::ssl') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_https') }
-    it { should create_class('pki') }
-    it { should create_pki__copy('/etc/httpd/conf') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::ssl') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_https') }
+    it { is_expected.to create_class('pki') }
+    it { is_expected.to create_pki__copy('/etc/httpd/conf') }
   end
 
   context 'no_enable_iptables' do
     let(:params){{ 'enable_iptables' => false }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::ssl') }
-    it { should_not create_iptables__add_tcp_stateful_listen('allow_https') }
-    it { should create_class('pki') }
-    it { should create_pki__copy('/etc/httpd/conf') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::ssl') }
+    it { is_expected.not_to create_iptables__add_tcp_stateful_listen('allow_https') }
+    it { is_expected.to create_class('pki') }
+    it { is_expected.to create_pki__copy('/etc/httpd/conf') }
   end
 
   context 'no_use_simp_pki' do
     let(:params){{ 'use_simp_pki' => false }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::ssl') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_https') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::ssl') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_https') }
 # This doesn't work for undetermined reasons
 #    it { should_not contain_class('pki') }
-    it { should_not create_pki__copy('/etc/httpd/conf') }
+    it { is_expected.not_to create_pki__copy('/etc/httpd/conf') }
   end
 
   context 'use_simp_pki_and_filled_cert_source' do
@@ -53,14 +53,14 @@ describe 'apache::ssl' do
       'cert_source'  => '/tmp/foo'
     }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::ssl') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_https') }
-    it { should create_class('pki') }
-    it { should create_pki__copy('/etc/httpd/conf') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::ssl') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_https') }
+    it { is_expected.to create_class('pki') }
+    it { is_expected.to create_pki__copy('/etc/httpd/conf') }
     it {
-      should_not create_file('/etc/httpd/conf/pki').with({
+      is_expected.not_to create_file('/etc/httpd/conf/pki').with({
         'source' => params['cert_source']
       })
     }
@@ -72,15 +72,15 @@ describe 'apache::ssl' do
       'cert_source'  => '/tmp/foo'
     }}
 
-    it { should compile.with_all_deps }
-    it { should create_class('apache') }
-    it { should create_class('apache::ssl') }
-    it { should create_iptables__add_tcp_stateful_listen('allow_https') }
+    it { is_expected.to compile.with_all_deps }
+    it { is_expected.to create_class('apache') }
+    it { is_expected.to create_class('apache::ssl') }
+    it { is_expected.to create_iptables__add_tcp_stateful_listen('allow_https') }
 # This doesn't work for undetermined reasons
 #    it { should_not create_class('pki') }
-    it { should_not create_pki__copy('/etc/httpd/conf') }
+    it { is_expected.not_to create_pki__copy('/etc/httpd/conf') }
     it {
-      should create_file('/etc/httpd/conf/pki').with({
+      is_expected.to create_file('/etc/httpd/conf/pki').with({
         'source' => params['cert_source']
       })
     }

--- a/spec/defines/add_site_spec.rb
+++ b/spec/defines/add_site_spec.rb
@@ -16,7 +16,7 @@ describe 'apache::add_site' do
   let(:title) {'test'}
   let(:params) {{ :content => 'test' }}
 
-  it { should create_class('apache') }
+  it { is_expected.to create_class('apache') }
 
-  it { should contain_file("/etc/httpd/conf.d/#{title}.conf").with_content('test') }
+  it { is_expected.to contain_file("/etc/httpd/conf.d/#{title}.conf").with_content('test') }
 end


### PR DESCRIPTION
This commit synchronizes all common static module assets with current SIMP
module standards.

Also:
- created metadata.json, .puppet-lint.rc, .travis.yml, .gitignore
- moved includes to the top of each class
- updated rspec tests to the new `expect` syntax
- bumped RPM to 4.1.0-20

SIMP-667 #comment updated `pupmod-simp-apache`
SIMP-733 #close #comment normalized common module assets