### PR TITLE
(SIMP-1054) Update static assets to fix spec tests

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,5 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-trailing_comma-check
+--no-empty_string-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,61 +11,60 @@ script:
 notifications:
   email: false
 rvm:
-  - 1.8.7
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
+  - 1.9.3
 env:
   global:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
-  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 4.4.0"
     - PUPPET_VERSION="~> 3.5.0"
     - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
     - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-    - PUPPET_VERSION="~> 3.8.0"
     - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
+    - PUPPET_VERSION="~> 4.3.0"
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: 1.8.7
-    - rvm: 2.1.0
+    - rvm: 1.9.3
     - rvm: 2.2.1
     - env: PUPPET_VERSION="~> 3.5.0"
     - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 4.0.0"
     - env: PUPPET_VERSION="~> 4.1.0"
     - env: PUPPET_VERSION="~> 4.2.0"
+    - env: PUPPET_VERSION="~> 4.3.0"
+
 
   exclude:
-  # Ruby 1.8.7
-  # - Ruby 1.8.7 & Puppet 4.X is impossibru
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0"
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.2.0"
-
-  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
-  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
-  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-  - rvm: 1.8.7
+  # Ruby 1.9.3
+  - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.5.0"
-  - rvm: 1.8.7
+  - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.6.0"
-  - rvm: 1.8.7
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 1.9.3
     env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.2.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 4.3.0"
 
   # Ruby 2.1.0
   - rvm: 2.1.0
@@ -74,6 +73,8 @@ matrix:
     env: PUPPET_VERSION="~> 3.6.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
 
   # Ruby 2.2.1
   - rvm: 2.2.1
@@ -87,4 +88,10 @@ matrix:
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.8.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 4.2.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 4.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,28 @@
-# Variables:
-#
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-# PUPPET_VERSION   | specifies the version of the puppet gem to load
+# ------------------------------------------------------------------------------
+# Environment variables:
+#   SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+#   PUPPET_VERSION   | specifies the version of the puppet gem to load
+# ------------------------------------------------------------------------------
+# NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
+# ------------------------------------------------------------------------------
 puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
-group :development do
+group :test do
+  gem "rake"
   gem 'puppet', puppetversion
-  gem 'beaker-rspec'
-  gem 'vagrant-wrapper'
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "hiera-puppet-helper"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts", "~> 1.3"
+
+  gem 'puppet-lint-empty_string-check',   :require => false
+  gem 'puppet-lint-trailing_comma-check', :require => false
+
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
@@ -19,6 +31,25 @@ group :development do
       RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
     gem 'simp-rake-helpers'
   end
+end
 
-  gem 'google-api-client', '0.9.4'
+group :development do
+  gem "travis"
+  gem "travis-lint"
+  gem "travish"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
+  gem 'pry'
+  gem 'pry-doc'
+
+  # `listen` is a dependency of `guard`
+  # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
+  gem 'listen', '~> 3.0.6'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
+  gem 'simp-beaker-helpers', '>= 1.0.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
 require 'simp/rake/pupmod/helpers'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,6 @@ default_hiera_config =<<-EOM
   :datadir: "stub"
 :hierarchy:
   - "%{custom_hiera}"
-  - "%{spec_title}"
   - "%{module_name}"
   - "default"
 EOM


### PR DESCRIPTION
Before this patch, this module would fail its spec tests when
`STRICT_VARIABLES=yes` is set (as it is in Travis CI tests).
This was caused by the presence of the unset (and unused) variable
"spec_title" in the modules' fixture hieradata/hiera.yaml.

This commit fixes the issue by removing "spec_title" from
each module's hieradata/hiera.yaml.

SIMP-1054 #comment Fixed pupmod-simp-apache
SIMP-1070 #close Fixed spec failures when `STRICT_VARIABLES=yes`