### PR TITLE
(SIMP-1122) Copy non-simp::pki certs recursively

### DIFF
--- a/build/pupmod-apache.spec
+++ b/build/pupmod-apache.spec
@@ -1,6 +1,6 @@
 Summary: Apache Puppet Module
 Name: pupmod-apache
-Version: 4.1.2
+Version: 4.1.3
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -64,6 +64,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Sun May 22 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.3-0
+- Ensure that PKI certificates that are downloaded without using simp::pki are
+  copied recursively.
+
 * Thu Apr 14 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.2-0
 - Ensure that the munge_httpd_networks array is flattened on return. This is a
   Ruby 1.9 compatiblity issue.

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -108,12 +108,13 @@ class apache::ssl (
   }
   elsif  !empty($cert_source) {
     file { '/etc/httpd/conf/pki':
-      ensure => 'directory',
-      owner  => hiera('apache::conf::group','root'),
-      group  => hiera('apache::conf::group','apache'),
-      mode   => '0640',
-      source => $cert_source,
-      notify => Service['httpd']
+      ensure  => 'directory',
+      owner   => hiera('apache::conf::group','root'),
+      group   => hiera('apache::conf::group','apache'),
+      mode    => '0640',
+      source  => $cert_source,
+      recurse => true,
+      notify  => Service['httpd']
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-apache",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "author":  "simp",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",


### PR DESCRIPTION
When copying certificates from a non-simp::pki source, they must be
copied recursively.

SIMP-1122 #close