### PR TITLE
(SIMP-1251) Fix `apache_limits()`

### DIFF
--- a/build/pupmod-apache.spec
+++ b/build/pupmod-apache.spec
@@ -1,6 +1,6 @@
 Summary: Apache Puppet Module
 Name: pupmod-apache
-Version: 4.1.4
+Version: 4.1.5
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -65,6 +65,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Tue Jul 19 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 4.1.5-0
+- Add default Require to apache_limits() output
+
 * Thu Jun 30 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.1.4-0
 - Haveged included by default for entropy generation.
 

--- a/lib/puppet/parser/functions/apache_limits.rb
+++ b/lib/puppet/parser/functions/apache_limits.rb
@@ -129,6 +129,7 @@ module Puppet::Parser::Functions
         output << "<Limit #{k}>"
         output << "  Order allow,deny"
         output << "  #{v.join("\n  ")}"
+        output << "  Require all denied"
         output << "  Satisfy any"
         output << "</Limit>"
       end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-apache",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "author":  "simp",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",


### PR DESCRIPTION
This adds a default deny directive to the `Require` lists generated by
the `apaceh_limits()` function.