### PR TITLE
(SIMP-1574) Fix Forge `haveged` dependency name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.6-0
+- Fix Forge `haveged` dependency name
+
 * Tue Jul 19 2016 Lucas Yamanishi <lucas.yamanishi@onyxpoint.com> - 4.1.5-0
 - Add default Require to apache_limits() output
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,16 +1,19 @@
 {
-  "name":    "simp-apache",
-  "version": "4.1.5",
-  "author":  "simp",
+  "name": "simp-apache",
+  "version": "4.1.6",
+  "author": "simp",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/pupmod-simp-apache",
+  "source": "https://github.com/simp/pupmod-simp-apache",
   "project_page": "https://github.com/simp/pupmod-simp-apache",
-  "issues_url":   "https://simp-project.atlassian.net",
-  "tags": [ "simp", "apache" ],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "apache"
+  ],
   "dependencies": [
     {
-      "name": "simp/puppet-haveged",
+      "name": "simp/haveged",
       "version_requirement": ">= 0.3.0 < 1.0.0"
     },
     {


### PR DESCRIPTION
`metadata.json` erroneously claimed `simp/puppet-haveged` as a
dependency, which causes a fatal error when pushing to the Forge.

This patch corrects the dependency name  to `simp/haveged`.

SIMP-1574 #comment fixed pupmod-simp-apache