### PR TITLE
(SIMP-1450) Deconflict with plabs apache & concat

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Deconflict with the puppetlabs-apache module and move to the name
+  'simp_apache'
+
 * Wed Sep 28 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.6-0
 - Fix Forge `haveged` dependency name
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
 require 'simp/rake/pupmod/helpers'
 
 Simp::Rake::Pupmod::Helpers.new(File.dirname(__FILE__))
-

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -6,5 +6,7 @@ Requires: pupmod-simp-logrotate >= 4.1.0-0
 Requires: pupmod-simp-pki >= 3.0.0-0
 Requires: pupmod-simp-rsync >= 4.0.0-14
 Requires: pupmod-simp-rsyslog >= 4.1.0-0
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-apache-test >= 0.0.1
+Obsoletes: pupmod-simp-apache >= 4.1.5-0
+Provides: pupmod-simp-apache > 5.0.0-0

--- a/manifests/add_site.pp
+++ b/manifests/add_site.pp
@@ -17,21 +17,21 @@
 #   custom content on the fly.
 #
 #
-define apache::add_site (
+define simp_apache::add_site (
   $content = 'base'
 ) {
   validate_string( $content )
 
-  include 'apache'
+  include '::simp_apache'
 
   $_content = $content ? {
-    'base'  => template("apache/etc/httpd/conf.d/${name}.conf.erb"),
+    'base'  => template("${module_name}/etc/httpd/conf.d/${name}.conf.erb"),
     default => $content
   }
 
   file { "/etc/httpd/conf.d/${name}.conf":
-    owner   => hiera('apache::conf::group','root'),
-    group   => hiera('apache::conf::group','apache'),
+    owner   => pick($::simp_apache::conf::group,'root'),
+    group   => pick($::simp_apache::conf::group,'apache'),
     mode    => '0640',
     content => $_content,
     notify  => Service['httpd']

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -1,4 +1,4 @@
-# == Class: apache::conf
+# == Class: simp_apache::conf
 #
 # This class sets up apache.conf.
 #
@@ -43,7 +43,7 @@
 #
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class apache::conf (
+class simp_apache::conf (
   $httpd_timeout = '120',
   $keepalive = 'off',
   $maxkeepalive = '100',
@@ -78,7 +78,7 @@ class apache::conf (
   $rsyslog_target = '/var/log/httpd',
   $purge = true
 ) {
-  include '::apache'
+  include '::simp_apache'
 
   validate_integer($httpd_timeout)
   validate_array_member($keepalive,['on','off'])
@@ -124,7 +124,7 @@ class apache::conf (
     owner   => 'root',
     group   => $group,
     mode    => '0640',
-    content => template('apache/etc/httpd/conf/httpd.conf.erb'),
+    content => template("${module_name}/etc/httpd/conf/httpd.conf.erb"),
     notify  => Service['httpd']
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# == Class: apache
+# == Class: simp_apache
 #
 # This class configures an Apache server.  It ensures that the appropriate
 # files are in the appropriate places and can optionally rsync the
@@ -33,7 +33,7 @@
 #
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class apache (
+class simp_apache (
   $data_dir = versioncmp(simp_version(),'5') ? { '-1' => '/srv/www', default => '/var/www' },
   $rsync_server = hiera('rsync::server'),
   $rsync_timeout = hiera('rsync::timeout','2'),
@@ -48,17 +48,17 @@ class apache (
 
   compliance_map()
 
-  include '::apache::install'
-  include '::apache::conf'
+  include '::simp_apache::install'
+  include '::simp_apache::conf'
 
   if $ssl {
-    include '::apache::ssl'
-    Class['::apache::install'] -> Class['::apache::ssl']
+    include '::simp_apache::ssl'
+    Class['::simp_apache::install'] -> Class['::simp_apache::ssl']
   }
 
-  Class['::apache::install'] -> Class['::apache']
-  Class['::apache::install'] -> Class['::apache::conf']
-  Class['::apache::install'] ~> Service['httpd']
+  Class['::simp_apache::install'] -> Class['::simp_apache']
+  Class['::simp_apache::install'] -> Class['::simp_apache::conf']
+  Class['::simp_apache::install'] ~> Service['httpd']
 
   if $::operatingsystem in ['RedHat','CentOS'] {
     if (versioncmp($::operatingsystemmajrelease,'7') >= 0) {
@@ -89,7 +89,7 @@ class apache (
     owner  => 'root',
     group  => 'apache',
     mode   => '0640',
-    source => 'puppet:///modules/apache/magic',
+    source => "puppet:///modules/${module_name}/magic",
     notify => Service['httpd'],
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,8 @@
-# == Class: apache::install
+# == Class: simp_apache::install
 #
 # Package installation
 #
-class apache::install {
+class simp_apache::install {
 
   assert_private()
 
@@ -15,7 +15,7 @@ class apache::install {
     }
   }
 
-  if $::apache::ssl {
+  if $::simp_apache::ssl {
     package { 'mod_ssl': ensure => 'latest' }
   }
 }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -1,4 +1,4 @@
-# == Class: apache::ssl
+# == Class: simp_apache::ssl
 #
 # This class configures an Apache server with SSL support.  It ensures that
 # the appropriate files are in the appropriate places and have the correct
@@ -49,7 +49,7 @@
 #
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class apache::ssl (
+class simp_apache::ssl (
   $listen = '443',
   $client_nets = hiera('client_nets'),
   $ssl_cipher_suite = hiera('openssl::cipher_suite',['HIGH']),
@@ -79,7 +79,8 @@ class apache::ssl (
   validate_bool($enable_iptables)
   validate_bool($use_simp_pki)
   validate_bool($use_haveged)
-  include '::apache'
+
+  include '::simp_apache'
 
   compliance_map()
 
@@ -88,10 +89,10 @@ class apache::ssl (
   }
 
   file { '/etc/httpd/conf.d/ssl.conf':
-    owner   => hiera('apache::conf::group','root'),
-    group   => hiera('apache::conf::group','apache'),
+    owner   => pick($::simp_apache::conf::group,'root'),
+    group   => pick($::simp_apache::conf::group,'apache'),
     mode    => '0640',
-    content => template('apache/etc/httpd/conf.d/ssl.conf.erb'),
+    content => template("${module_name}/etc/httpd/conf.d/ssl.conf.erb"),
     notify  => Service['httpd']
   }
 
@@ -109,15 +110,15 @@ class apache::ssl (
     include '::pki'
 
     ::pki::copy { '/etc/httpd/conf':
-      group  => hiera('apache::conf::group','apache'),
+      group  => pick($::simp_apache::conf::group,'apache'),
       notify => Service['httpd']
     }
   }
   elsif  !empty($cert_source) {
     file { '/etc/httpd/conf/pki':
       ensure  => 'directory',
-      owner   => hiera('apache::conf::group','root'),
-      group   => hiera('apache::conf::group','apache'),
+      owner   => pick($::simp_apache::conf::group,'root'),
+      group   => pick($::simp_apache::conf::group,'apache'),
       mode    => '0640',
       source  => $cert_source,
       recurse => true,

--- a/manifests/validate.pp
+++ b/manifests/validate.pp
@@ -1,4 +1,4 @@
-# == Class apache::validate
+# == Class simp_apache::validate
 #
 # This class should be used as input to validate_deep_hash when
 # managing 'ldap' or 'limits' ACLs
@@ -10,7 +10,7 @@
 #
 # * Trevor Vaughan <tvaughan@onyxpoint.com>
 #
-class apache::validate {
+class simp_apache::validate {
   $method_acl = {
     'method' => {
       'file' => {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-  "name": "simp-apache",
-  "version": "4.1.6",
+  "name": "simp-simp_apache",
+  "version": "5.0.0",
   "author": "simp",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",
@@ -30,7 +30,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/logrotate",


### PR DESCRIPTION
This update renames the old SIMP 'apache' module to 'simp_apache' so
that we fully deconflict with the widely used 'puppetlabs/apache'
module.

Additionally, it pulls in the changes necessary to support the updated
'simpcat' which deconflicts with the 'puppetlabs/concat' module.

SIMP-1450 #comment Deconflict with puppetlabs/apache and puppetlabs/concat
SIMP-843 #comment Deconflict the 'apache' module
SIMP-6 #comment Deconflict the 'apache' module
