### PR TITLE
(SIMP-1677) Remove deprecated Puppet.newtype

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,7 +11,10 @@ fixtures:
     augeasproviders_grub:
       repo: "https://github.com/simp/augeasproviders_grub"
       branch: "simp-master"
-    compliance_markup: "https://github.com/simp/pupmod-simp-compliance_markup"
+    compliance_markup:
+      repo: "https://github.com/simp/pupmod-simp-compliance_markup"
+      branch: "master"
+#      branch: "1.0.2"
     haveged:
       repo: "https://github.com/simp/puppet-haveged"
       branch: "simp-master"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Fri Nov 11 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0-0
+- Fixed bug in which htaccess type would fail to compile as it
+  required 'sha1' instead of 'digest/sha1'
+- Fixed bug in which htaccess provider dropped the first line
+  of an existing htaccess file, when that line did not contain
+  the Puppet-management warning comment.
+- Eliminated use of deprecated Puppet.newtype
+
 * Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
 - Deconflict with the puppetlabs-apache module and move to the name
   'simp_apache'

--- a/lib/puppet/provider/htaccess/htaccess.rb
+++ b/lib/puppet/provider/htaccess/htaccess.rb
@@ -35,8 +35,11 @@ Puppet::Type.type(:htaccess).provide :htaccess do
       fh = File.open(target,'r')
 
       # Check for the edit message and add if necessary.
-      if fh.eof? or ( not fh.readline.chomp.eql?(HTACCESS_EDIT_MSG) ) then
+      if fh.eof?
         outfile.puts(HTACCESS_EDIT_MSG)
+      elsif not fh.readline.chomp.eql?(HTACCESS_EDIT_MSG)
+        outfile.puts(HTACCESS_EDIT_MSG)
+        fh.rewind
       else
         fh.rewind
       end
@@ -75,7 +78,6 @@ Puppet::Type.type(:htaccess).provide :htaccess do
 
       fh.close
       outfile.close
-
       FileUtils.cp(tmpname,target)
       FileUtils.rm(tmpname)
     rescue Exception => e

--- a/lib/puppet/type/htaccess.rb
+++ b/lib/puppet/type/htaccess.rb
@@ -1,76 +1,74 @@
-module Puppet
-  newtype(:htaccess) do
-    @doc = "Manages the contents of htaccess files using the htpasswd command.
-            Right now the $namevar must be a path/user combination as
-            documented under the $name parameter. Hopefully, this can be fixed
-            in the future.
+Puppet::Type.newtype(:htaccess) do
+  @doc = "Manages the contents of htaccess files using the htpasswd command.
+          Right now the $namevar must be a path/user combination as
+          documented under the $name parameter. Hopefully, this can be fixed
+          in the future.
 
-            Note: If you want different permissions than root:root 640, you
-            will need to create a 'file' object to manage the target file."
+          Note: If you want different permissions than root:root 640, you
+          will need to create a 'file' object to manage the target file."
 
-    ensurable
+  ensurable
 
-    newparam(:name) do
-      isnamevar
-      desc "A variable of the format 'path:username'. This will hopefully be
-            split in the future but, for now, you cannot use usernames that
-            contain a colon ':'."
+  newparam(:name) do
+    isnamevar
+    desc "A variable of the format 'path:username'. This will hopefully be
+          split in the future but, for now, you cannot use usernames that
+          contain a colon ':'."
 
-      validate do |value|
-        target = value.split(':').first
+    validate do |value|
+      target = value.split(':').first
 
-        fail Puppet::Error, "name is missing either the path or the username. Name format must be 'path:username'" if value !~ /.+:.+/
+      fail Puppet::Error, "name is missing either the path or the username. Name format must be 'path:username'" if value !~ /.+:.+/
 
-        fail Puppet::Error, "File paths must be fully qualified, not #{target}" if value !~ /^\//
-      end
+      fail Puppet::Error, "File paths must be fully qualified, not #{target}" if value !~ /^\//
     end
-
-    newproperty(:password) do
-      desc "The user's new password either as an SHA hash or as plain text.
-            Anything not prefixed with {SHA} will be treated as plain text."
-      
-      def insync?(is)
-        is == @should.to_s
-      end
-
-      def sync
-        provider.passwd_sync
-      end
-
-      def retrieve
-        return provider.passwd_retrieve
-      end
-
-      munge do |value|
-        unless value =~ /^\{SHA\}/
-          require 'sha1'
-          require 'base64'
-          value = "{SHA}"+Base64.encode64(Digest::SHA1.digest(value)).chomp!
-        end
-
-        value
-      end
-    end
-
-    autorequire(:file) do
-      torequire = self[:name].split(':').first
-
-      if catalog.resources.find_all { |r| r.is_a?(Puppet::Type.type(:file)) and r[:name] == torequire }.empty? then
-        err "You must declare a 'file' object to manage #{torequire}!"
-      end
-
-      torequire
-    end
-
-    validate do
-      required_fields = [ :password ]
-
-      required_fields.each do |req|
-        unless @parameters.include?(req)
-          fail Puppet::Error, "You must specify #{req}."
-        end
-      end
-    end
-
   end
-end          
+
+  newproperty(:password) do
+    desc "The user's new password either as an SHA hash or as plain text.
+          Anything not prefixed with {SHA} will be treated as plain text."
+
+    def insync?(is)
+      is == @should[0]
+    end
+
+    def sync
+      provider.passwd_sync
+    end
+
+    def retrieve
+      return provider.passwd_retrieve
+    end
+
+    munge do |value|
+      unless value =~ /^\{SHA\}/
+        require 'digest/sha1'
+        require 'base64'
+        value = "{SHA}"+Base64.encode64(Digest::SHA1.digest(value)).chomp!
+      end
+
+      value
+    end
+  end
+
+  autorequire(:file) do
+    torequire = self[:name].split(':').first
+
+    if catalog.resources.find_all { |r| r.is_a?(Puppet::Type.type(:file)) and r[:name] == torequire }.empty? then
+      err "You must declare a 'file' object to manage #{torequire}!"
+    end
+
+    torequire
+  end
+
+  validate do
+    required_fields = [ :password ]
+
+    required_fields.each do |req|
+      unless @parameters.include?(req)
+        fail Puppet::Error, "You must specify #{req}."
+      end
+    end
+  end
+
+end

--- a/spec/acceptance/htaccess_spec.rb
+++ b/spec/acceptance/htaccess_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper_acceptance'
+
+test_name "htaccess type/provider"
+
+['6', '7'].each do |os_major_version|
+  describe "htaccess type/provider for CentOS #{os_major_version}" do
+    let(:host) {only_host_with_role( hosts, "server#{os_major_version}" ) }
+
+    let(:manifest1) { <<EOM
+htaccess { 'user1': name => '/root/htaccess.txt:user1', password=>"user1's password" }
+htaccess { 'user2': name => '/root/htaccess.txt:user2', password=>"{SHA}yLo2mwINaPQsTgevY0gyfH9mxk4=" }
+EOM
+    }
+
+    let(:manifest2) { <<EOM
+file { '/root/htaccess.txt': ensure => present }
+htaccess { 'user1': name => '/root/htaccess.txt:user1', password=>"user1's password" }
+htaccess { 'user2': name => '/root/htaccess.txt:user2', password=>"{SHA}yLo2mwINaPQsTgevY0gyfH9mxk4=" }
+EOM
+    }
+
+    let(:manifest3) { <<EOM
+file { '/root/htaccess.txt': ensure => present }
+htaccess { 'user1': name => '/root/htaccess.txt:user1', password=>"user1's password", ensure=>absent }
+htaccess { 'user2': name => '/root/htaccess.txt:user2', password=>"{SHA}yLo2mwINaPQsTgevY0gyfH9mxk4=", ensure=>absent }
+htaccess { 'user3': name => '/root/htaccess.txt:user3', password=>"user3's password" }
+EOM
+}
+
+    it 'should require file resource' do
+      apply_manifest_on(host, manifest1, :expect_failures => true) do
+        expect(stderr).to match(/You must declare a 'file' object to manage \/root\/htaccess.txt!/m)
+      end
+    end
+
+    it 'should work with no errors' do
+      apply_manifest_on(host, manifest2, :catch_failures => true)
+
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+user2:{SHA}yLo2mwINaPQsTgevY0gyfH9mxk4=
+user1:{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=
+EOM
+      on host, 'cat /root/htaccess.txt', :acceptable_exit_codes => 0 do
+         expect(stdout).to eq(expected)
+      end
+    end
+
+    it 'should be idempotent' do
+      apply_manifest_on(host, manifest2, :catch_changes => true)
+    end
+
+    it 'should be be ensurable' do
+      apply_manifest_on(host, manifest3, :catch_failures => true)
+
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+user3:{SHA}UJWYsWH31uLIUPa4iazyItrNbys=
+EOM
+      on host, 'cat /root/htaccess.txt', :acceptable_exit_codes => 0 do
+         expect(stdout).to eq(expected)
+      end
+    end
+
+  end
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,17 @@
+HOSTS:
+  server7:
+    roles:
+      - server7
+      - default
+    platform: el-7-x86_64
+    box :     centos/7
+    hypervisor : vagrant
+  server6:
+    roles:
+      - server6
+    platform: el-6-x86_64
+    box :     centos/6
+    hypervisor : vagrant
+CONFIG:
+  type: foss
+  vagrant_memsize: 256

--- a/spec/unit/puppet/provider/htaccess/htaccess_spec.rb
+++ b/spec/unit/puppet/provider/htaccess/htaccess_spec.rb
@@ -1,0 +1,158 @@
+require 'spec_helper'
+require 'tempfile'
+
+provider_class = Puppet::Type.type(:htaccess).provider(:htaccess)
+describe provider_class do
+  before :each do
+    FileUtils.stubs(:chown).returns(true) # can't chown root:root
+    tmp = Tempfile.new('htaccess_tmp')
+    @htaccess_file = tmp.path
+    tmp.close!
+  end
+
+  after :each do
+    FileUtils.rm_f(@htaccess_file)
+  end
+
+  let(:user1) { 'user1' }
+  let :resource do
+    Puppet::Type::Htaccess.new(
+      {:name => "#{@htaccess_file}:#{user1}", :password => "#{user1}'s password"}
+    )
+  end
+
+  context "when creating htaccess file" do
+    let :provider do
+      provider_class.new(resource)
+    end
+
+    it 'should not exist' do
+      expect { provider.exists? }.to raise_error(/No such file or directory .*#{@htaccess_file}/)
+      expect(provider.passwd_retrieve).to be_nil
+    end
+
+    it 'should create htaccess file with banner and one user entry' do
+      provider.create
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+user1:{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=
+EOM
+      expect(IO.read(@htaccess_file)).to eq(expected)
+      expect(provider.exists?).to eq(true)
+      expect(provider.passwd_retrieve).to eq("{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=")
+    end
+  end
+
+  context "when adding to htaccess file with banner" do
+    let :provider do
+      provider_class.new(resource)
+    end
+
+    it 'should add user entry to end of htaccess file' do
+      File.open(@htaccess_file, 'w') do |file|
+        file.puts("# This file managed by Puppet. Please do not edit by hand!")
+        file.puts("anotheruser:{SHA}deadbeefdeadbeefdeadbeefdead")
+      end
+
+      provider.create
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+anotheruser:{SHA}deadbeefdeadbeefdeadbeefdead
+user1:{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=
+EOM
+      expect(IO.read(@htaccess_file)).to eq(expected)
+      expect(provider.exists?).to eq(true)
+      expect(provider.passwd_retrieve).to eq("{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=")
+    end
+  end
+
+  context "when adding to htaccess file missing banner" do
+    let :provider do
+      provider_class.new(resource)
+    end
+
+    it 'should add banner and user entry to htaccess file' do
+      File.open(@htaccess_file, 'w') do |file|
+        file.puts("anotheruser:{SHA}deadbeefdeadbeefdeadbeefdead")
+      end
+
+      provider.create
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+anotheruser:{SHA}deadbeefdeadbeefdeadbeefdead
+user1:{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=
+EOM
+      expect(IO.read(@htaccess_file)).to eq(expected)
+      expect(provider.exists?).to eq(true)
+      expect(provider.passwd_retrieve).to eq("{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=")
+    end
+  end
+
+  context "when adding to htaccess file using hashed password" do
+    let :resource2 do
+      Puppet::Type::Htaccess.new(
+        {:name => "#{@htaccess_file}:#{user1}", :password => "{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo="}
+      )
+    end
+
+    let :provider do
+      provider_class.new(resource2)
+    end
+
+    it 'should add user entry using pre-hashed password to htaccess file' do
+      provider.create
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+user1:{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=
+EOM
+      expect(IO.read(@htaccess_file)).to eq(expected)
+      expect(provider.exists?).to eq(true)
+      expect(provider.passwd_retrieve).to eq("{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=")
+    end
+  end
+  
+  context "when updating htaccess file" do
+    let :provider do
+      provider_class.new(resource)
+    end
+
+    it 'should replace password of user entry in htaccess file' do
+      File.open(@htaccess_file, 'w') do |file|
+        file.puts("#{user1}:{SHA}deadbeefdeadbeefdeadbeefdead")
+      end
+
+      provider.passwd_sync
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+user1:{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=
+EOM
+      expect(IO.read(@htaccess_file)).to eq(expected)
+      expect(provider.exists?).to eq(true)
+      expect(provider.passwd_retrieve).to eq("{SHA}CLub7iwpjkqz0enKLoRcbiDtUCo=")
+    end
+  end
+
+  context "when removing user entry from htaccess file" do
+    let :provider do
+      provider_class.new(resource)
+    end
+
+    it 'should remove user entry in htaccess file' do
+      File.open(@htaccess_file, 'w') do |file|
+        file.puts("user0:{SHA}deadbeefdeadbeefdeadbeefdead")
+        file.puts("#{user1}:{SHA}deadbeefdeadbeefdeadbeefdead")
+        file.puts("user2:{SHA}deadbeefdeadbeefdeadbeefdead")
+      end
+
+      provider.destroy
+      expected = <<EOM
+# This file managed by Puppet. Please do not edit by hand!
+user0:{SHA}deadbeefdeadbeefdeadbeefdead
+user2:{SHA}deadbeefdeadbeefdeadbeefdead
+EOM
+      expect(IO.read(@htaccess_file)).to eq(expected)
+      expect(provider.exists?).to eq(false)
+      expect(provider.passwd_retrieve).to be_nil
+    end
+  end
+end

--- a/spec/unit/puppet/type/htaccess_spec.rb
+++ b/spec/unit/puppet/type/htaccess_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+htaccess_type = Puppet::Type.type(:htaccess)
+
+describe htaccess_type do
+  it "should require <fully-qualified path>:<username> for the name param" do
+    expect {
+      htaccess_type.new(
+        :name => '/fully/qualified/path:username',
+        :password => 'badpassword'
+      )
+    }.to_not raise_error
+
+    expect {
+      htaccess_type.new(
+        :name => 'onefield',
+        :password => 'badpassword'
+      )
+    }.to raise_error(%r{name is missing either the path or the username. Name format must be 'path:username'})
+
+    expect {
+      htaccess_type.new(
+        :name => ':empty_first_field',
+        :password => 'badpassword'
+      )
+    }.to raise_error(%r{name is missing either the path or the username. Name format must be 'path:username'})
+
+    expect {
+      htaccess_type.new(
+        :name => 'empty_second_field:',
+        :password => 'badpassword'
+      )
+    }.to raise_error(%r{name is missing either the path or the username. Name format must be 'path:username'})
+
+    expect {
+      htaccess_type.new(
+        :name => 'not/fully/qualified/path:username',
+        :password => 'badpassword'
+      )
+    }.to raise_error(%r{File paths must be fully qualified, not not/fully/qualified/path})
+  end
+
+  it "should require the password param" do
+    expect { htaccess_type.new( :name => '/fully/qualified/path:username' ) }.to raise_error(%r{You must specify password.})
+  end
+
+end


### PR DESCRIPTION
- Eliminated use of deprecated Puppet.newtype
- Fixed bug in which htaccess type would fail to compile as it
  required 'sha1' instead of 'digest/sha1'
- Fixed bug in which htaccess provider dropped the first line
  of an existing htaccess file, when that line did not contain
  the Puppet-management warning comment.

SIMP-1882 #close