### PR TITLE
(SIMP-2220) Prevent log duplication and log where intended

### DIFF
--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,3 +2,5 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-80chars-check
+--no-trailing_comma-check
+--no-empty_string_assignment-check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Thu Dec 01 2016 Nicholas Hughes, Nick Markowski <nmarkowski@keywcorp.com> - 5.0.1-0
+- Prevent log duplication and log where intended    
+- Changed naming to XX_ or YY_ to come before the default Z_default.conf
+  for local rules, but after the numbered configs used by the log_server
+  class.
+
 * Wed Nov 23 2016 Jeanne Greulich <jgreulich.simp@onyxpoint.com> - 5.0.0-0
 - update requirement versions
 

--- a/build/package_metadata.yaml
+++ b/build/package_metadata.yaml
@@ -1,6 +1,0 @@
----
-# This RPM is required by the main SIMP RPM
-optional: false
-valid_versions :
- - '4\.(2|1).*'
- - '5\.(1|0).*'

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -139,12 +139,12 @@ class simp_apache::conf (
 
   if $enable_logging or hiera('use_simp_logging',false) {
     include '::rsyslog'
-    rsyslog::rule::local { '10apache_error':
+    rsyslog::rule::local { 'XX_apache_error':
       rule            => 'if ($programname == \'httpd\' and $syslogseverity-text == \'err\') then',
       target_log_file => "${rsyslog_target}/error_log",
       stop_processing => true
     }
-    rsyslog::rule::local { '10apache_access':
+    rsyslog::rule::local { 'YY_apache_access':
       rule            => 'if ($programname == \'httpd\') then',
       target_log_file => "${rsyslog_target}/access_log",
       stop_processing => true

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_apache",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "SIMP Team",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",

--- a/spec/classes/conf_spec.rb
+++ b/spec/classes/conf_spec.rb
@@ -12,11 +12,8 @@ describe 'simp_apache::conf' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('simp_apache::conf') }
           it { is_expected.not_to create_iptables__add_tcp_stateful_listen('allow_http') }
-          # Once the SIMP globals change for SIMPv6, these will actually be the defaults.
-          #  it { should_not create_rsyslog__rule__local('10apache_error') }
-          #  it { should_not create_rsyslog__rule__local('10apache_access') }
-          it { is_expected.to create_rsyslog__rule__local('10apache_error') }
-          it { is_expected.to create_rsyslog__rule__local('10apache_access') }
+          it { is_expected.to create_rsyslog__rule__local('XX_apache_error') }
+          it { is_expected.to create_rsyslog__rule__local('YY_apache_access') }
         end
 
         context 'enable_iptables' do
@@ -32,8 +29,8 @@ describe 'simp_apache::conf' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_class('simp_apache::conf') }
           it { is_expected.to create_class('rsyslog') }
-          it { is_expected.to create_rsyslog__rule__local('10apache_error') }
-          it { is_expected.to create_rsyslog__rule__local('10apache_access') }
+          it { is_expected.to create_rsyslog__rule__local('XX_apache_error') }
+          it { is_expected.to create_rsyslog__rule__local('YY_apache_access') }
         end
       end
     end


### PR DESCRIPTION
- Changed naming to XX_ or YY_ to come before the default Z_default.conf
  for local rules, but after the numbered configs used by the log_server
  class.

SIMP-2220 #close
SIMP-1446 #comment related to changes in log_server