### PR TITLE
(SIMP-2472) Updated application cert dir

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Tue Jan 10 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Updated pki scheme
+- Application certs are managed in /etc/pki/simp_apps/simp_apache/x509
 
 * Fri Dec 30 2016 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-0
 - Renamed `add_site` to `site`

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -26,9 +26,9 @@
 #
 # @param pki
 #   * If 'simp', include SIMP's pki module and use pki::copy to manage
-#     application certs in /etc/pki/simp_apps/simp_apache/pki
+#     application certs in /etc/pki/simp_apps/simp_apache/x509
 #   * If true, do *not* include SIMP's pki module, but still use pki::copy
-#     to manage certs in /etc/pki/simp_apps/simp_apache/pki
+#     to manage certs in /etc/pki/simp_apps/simp_apache/x509
 #   * If false, do not include SIMP's pki module and do not use pki::copy
 #     to manage certs.  You will need to appropriately assign a subset of:
 #     * app_pki_dir
@@ -39,7 +39,7 @@
 #
 # @param app_pki_external_source
 #   * If pki = 'simp' or true, this is the directory from which certs will be
-#     copied, via pki::copy.  Defaults to /etc/pki/simp.
+#     copied, via pki::copy.  Defaults to /etc/pki/simp/x509.
 #
 #   * If pki = false, this variable has no effect.
 #
@@ -68,8 +68,8 @@ class simp_apache::ssl (
   String                         $sslverifyclient         = 'require',
   Integer                        $sslverifydepth          = 10,
   Variant[Boolean,Enum['simp']]  $pki                     = simplib::lookup('simp_options::pki', { 'default_value' => false }),
-  Stdlib::Absolutepath           $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp' }),
-  Stdlib::AbsolutePath           $app_pki_dir             = '/etc/pki/simp_apps/simp_apache/pki',
+  Stdlib::Absolutepath           $app_pki_external_source = simplib::lookup('simp_options::pki::source', { 'default_value' => '/etc/pki/simp/x509' }),
+  Stdlib::AbsolutePath           $app_pki_dir             = '/etc/pki/simp_apps/simp_apache/x509',
   Stdlib::AbsolutePath           $app_pki_ca_dir          = "${app_pki_dir}/cacerts",
   Stdlib::AbsolutePath           $app_pki_cert            = "${app_pki_dir}/public/${facts['fqdn']}.pub",
   Stdlib::AbsolutePath           $app_pki_key             = "${app_pki_dir}/private/${facts['fqdn']}.pem",

--- a/spec/acceptance/suites/default/class_spec.rb
+++ b/spec/acceptance/suites/default/class_spec.rb
@@ -6,13 +6,12 @@ describe 'apache class' do
   hosts.each do |host|
 
     context 'basic parameters' do
-      let(:manifest) {
-        "class { 'simp_apache': }"
-      }
+      let(:manifest) { "include 'simp_apache'" }
       let(:host_fqdn) { fact_on(host, 'fqdn') }
       let(:hieradata) {{
-        'simp_apache::rsync_web_root'               => false,
-        'simp_apache::ssl::app_pki_external_source' => '/etc/pki/simp-testing/pki/',
+        'simp_apache::rsync_web_root' => false,
+        'simp_options::pki'           => true,
+        'simp_options::pki::source'   => '/etc/pki/simp-testing/pki/'
       }}
 
       it 'should work with no errors' do
@@ -29,6 +28,5 @@ describe 'apache class' do
         expect(result.output).to match(/You don't have permission to access \//)
       end
     end
-
   end
 end

--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -38,6 +38,7 @@ describe 'simp_apache::ssl' do
           it { is_expected.to_not create_iptables__listen__tcp_stateful('allow_https') }
           it { is_expected.to contain_class('pki') }
           it { is_expected.to create_pki__copy('simp_apache') }
+          it { is_expected.to create_file('/etc/pki/simp_apps/simp_apache/x509') }
         end
 
         context 'with haveged = false' do


### PR DESCRIPTION
- Application certs now managed in /etc/pki/simp_apps/simp_apache/x509

SIMP-2472 #comment Done in simp_apache