### PR TITLE
(SIMP-2492) Remove mod_ldap from CentOS7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Jan 16 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-0
+- Fixed dependency logic with mod_ldap to not install it on CentOS 7
+
 * Tue Jan 10 2017 Nick Markowski <nmarkowski@keywcorp.com> - 6.0.0-0
 - Updated pki scheme
 - Application certs are managed in /etc/pki/simp_apps/simp_apache/x509

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -6,7 +6,7 @@ class simp_apache::install {
   package { 'httpd': ensure => 'latest' }
 
   if $facts['os']['name'] in ['RedHat','CentOS'] {
-    if (versioncmp($facts['os']['release']['major'],'7') >= 0) {
+    if $facts['os']['release']['major'] == 6 {
       package { 'mod_ldap': ensure => 'latest' }
     }
   }


### PR DESCRIPTION
mod_ldap is included in the httpd package in CentOS7

SIMP-2492 #close