### PR TITLE
(SIMP-3347) simp_apache Convert to Puppet 4 custom functions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Thu Jun 22 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.1-0
+- Create namespaced, Puppet 4 versions of externally-used Puppet 3
+  functions and mark the Puppet 3 functions as deprecated. They will
+  be removed in a later release.
+  - apache_auth should be replaced with simp_apache::auth
+  - apache_limits should be replaced with simp_apache::limits
+  - munge_httpd_networks should be replaced with simp_apache::munge_httpd_networks
+
 * Mon Jan 23 2017 Nick Miller <nick.miller@onyxpoint.com> - 6.0.0-0
 - Fixed dependency logic with mod_ldap to not install it on CentOS 7
 - Rsyslog calls no longer include implied logic

--- a/lib/puppet/functions/simp_apache/auth.rb
+++ b/lib/puppet/functions/simp_apache/auth.rb
@@ -1,0 +1,136 @@
+# Takes a hash of arguments related to Apache 'Auth' settings and
+# returns a reasonably formatted set of options.
+#
+# Currently, only htaccess and LDAP support are implemented.
+Puppet::Functions.create_function(:'simp_apache::auth') do
+
+  # @param auth_hash Hash containing desired Apache authentication
+  #    methods and relevant parameters as key value pairs. The
+  #    key is the authentication method, while the corresponding
+  #    value is a Hash of relevant parameters.
+  # @return [String] Formatted Apache authentication settings
+  #
+  # @example Htaccess and LDAP authentication:
+  #   simp_apache::auth({
+  #     # Htaccess support
+  #     'file' => {
+  #       'enable'    => 'true',
+  #       'user_file' => '/etc/httpd/conf.d/test/.htdigest'
+  #     }
+  #     'ldap'    => {
+  #       'enable'      => 'true',
+  #       # The LDAP server URI in Apache form.
+  #       'url'         => ['ldap://server1','ldap://server2'],
+  #       # Must be one of 'NONE', 'SSL', 'TLS', or 'STARTTLS'
+  #       'security'    => 'STARTTLS',
+  #       'binddn'      => 'cn=happy,ou=People,dc=your,dc=domain',
+  #       'bindpw'      => 'birthday',
+  #       'search'      => 'ou=People,dc=your,dc=domain',
+  #       # Whether or not your LDAP groups are POSIX groups.
+  #       'posix_group' => 'true'
+  #      }
+  #    }
+  #   )
+  #
+  #   Output:
+  #     AuthName "Please Authenticate"
+  #     AuthType Basic
+  #     AuthBasicProvider ldap file
+  #     AuthLDAPUrl "ldap://server1 server2/ou=People,dc=your,dc=domain" STARTTLS
+  #     AuthLDAPBindDN "cn=happy,ou=People,dc=your,dc=domain',
+  #     AuthLDAPBindPassword 'birthday'
+  #     AuthLDAPGroupAttributeIsDN off
+  #     AuthLDAPGroupAttribute memberUid
+  #     AuthUserFile /etc/httpd/conf.d/elasticsearch/.htdigest
+  #
+  dispatch :format_auth do
+    required_param 'Hash', :auth_hash
+  end
+
+  def format_auth(auth_hash)
+    apache_auth_content = []
+
+    enabled_methods = []
+    method_content = []
+
+    auth_hash.keys.each do |auth_method|
+      next unless true?(auth_hash[auth_method]['enable'])
+
+      begin
+        send("auth_#{auth_method}", auth_hash[auth_method], method_content)
+        enabled_methods << auth_method
+      rescue NoMethodError => e
+        fail("simp_apache::auth(): Error, '#{auth_method}' not yet supported")
+      end
+    end
+
+    # If, for some reason, all methods were disabled, there's nothing to do
+    # here.
+    unless enabled_methods.empty?
+      apache_auth_content << 'AuthName "Please Authenticate"'
+      apache_auth_content << "AuthType Basic"
+      apache_auth_content << "AuthBasicProvider #{enabled_methods.join(' ')}"
+      apache_auth_content += method_content
+    end
+
+    return apache_auth_content.join("\n")
+  end
+
+  def true?(val)
+    return val.to_s.downcase == 'true'
+  end
+
+  def check_required_opts(required_opts,opts)
+    opt_test = required_opts - opts
+    unless opt_test.empty?
+      fail("simp_apache::auth(): Error, missing option(s) '#{opt_test.join(', ')}'")
+    end
+  end
+
+  def auth_ldap(opts,content)
+    required_opts = [
+      'url',
+      'search',
+      'posix_group'
+    ]
+
+    valid_sec_methods = [
+      'NONE',
+      'SSL',
+      'TLS',
+      'STARTTLS'
+    ]
+
+    check_required_opts(required_opts,opts.keys)
+
+    ldapuri = 'ldap://' + Array(opts['url']).join(' ').gsub(/ldap:\/\//,'')
+    ldapuri = ldapuri + '/' + opts['search']
+    ldapuri = '"' + ldapuri + '"'
+
+    if opts['security']
+      unless valid_sec_methods.include?(opts['security'])
+        fail("simp_apache::auth(): Error, 'security' must be one of {#{valid_sec_methods.join(', ')}}. Got: '#{opts['security']}'")
+      end
+      ldapuri = "#{ldapuri} #{opts['security']}"
+    end
+
+    content << "AuthLDAPUrl #{ldapuri}"
+    if opts['binddn']
+      content << "AuthLDAPBindDN \"#{opts['binddn']}\""
+      content << "AuthLDAPBindPassword '#{opts['bindpw'].gsub(/'/, "\\\\'")}'" if opts['bindpw']
+    end
+
+    if true?(opts['posix_group'])
+      content << "AuthLDAPGroupAttributeIsDN off"
+      content << "AuthLDAPGroupAttribute memberUid"
+    end
+  end
+
+  def auth_file(opts,content)
+    required_opts = [ 'user_file' ]
+
+    check_required_opts(required_opts,opts.keys)
+
+    content << "AuthUserFile #{opts['user_file']}"
+  end
+end

--- a/lib/puppet/functions/simp_apache/limits.rb
+++ b/lib/puppet/functions/simp_apache/limits.rb
@@ -1,0 +1,167 @@
+# Takes a hash of arguments related to Apache 'Limits' settings and
+# returns a reasonably formatted set of options.
+#
+# Currently, host, user ('valid-user' only), ldap-user, and 
+# ldap-group limits are supported.  The hash keys for these are
+# host limit: 'hosts'
+# user limit: 'users'; only applies for 'valid-user', all others assumed
+#   LDAP users
+# ldap-user limit: 'users'
+# ldap-group limit: 'ldap_groups'
+#
+# Groups of LDAP user primary groups are not supported since you would need
+# to know the GID.
+#
+Puppet::Functions.create_function(:'simp_apache::limits') do
+
+  # @param limits_hash Hash containing desired Apache limits
+  # @return [String] Formatted Apache limits settings
+  #
+  # @example  Host, user and ldap_group limits:
+  #
+  #   apache_limits(
+  #     {
+  #       # Set the defaults
+  #       # If this is omitted, it just defaults to 'GET'.
+  #       'defaults' => [ 'GET', 'POST', 'PUT' ],
+  #       # Allow the hosts/subnets below to GET, POST, and PUT to ES.
+  #       'hosts'  => {
+  #         '1.2.3.4'     => 'defaults',
+  #         '3.4.5.6'     => 'defaults',
+  #         '10.1.2.0/24' => 'defaults'
+  #       },
+  #       # You can make a special user 'valid-user' that will translate to
+  #       # allowing all valid users.
+  #       'users'  => {
+  #         # Allow user bob GET, POST, and PUT to ES.
+  #         'bob'     => 'defaults',
+  #         # Allow user alice GET, POST, PUT, and DELETE to ES.
+  #         'alice'   => ['GET','POST','PUT','DELETE']
+  #       },
+  #       'ldap_groups' => {
+  #          # Let the nice users read from ES.
+  #          "cn=nice_users,ou=Group,${::basedn}" => 'defaults'
+  #        }
+  #     }
+  #   )
+  #
+  #   Output:
+  #     <Limit DELETE>
+  #       Order allow,deny
+  #       Require user alice
+  #       Satisfy any
+  #     </Limit>
+  #
+  #     <Limit GET>
+  #       Order allow,deny
+  #       Allow from 1.2.3.4
+  #       Allow from 3.4.5.6
+  #       Allow from 10.1.2.0/24
+  #       Require ldap-user bob
+  #       Require ldap-user alice
+  #       Require ldap-group cn=nice_users,ou=Group,dc=your,dc=domain
+  #       Satisfy any
+  #     </Limit>
+  #
+  #     <Limit POST>
+  #       Order allow,deny
+  #       Allow from 1.2.3.4
+  #       Allow from 3.4.5.6
+  #       Allow from 10.1.2.0/24
+  #       Require ldap-user bob
+  #       Require ldap-user alice
+  #       Require ldap-group cn=nice_users,ou=Group,dc=your,dc=domain
+  #       Satisfy any
+  #     </Limit>
+  #
+  #     <Limit PUT>
+  #       Order allow,deny
+  #       Allow from 1.2.3.4
+  #       Allow from 3.4.5.6
+  #       Allow from 10.1.2.0/24
+  #       Require ldap-user bob
+  #       Require ldap-user alice
+  #       Require ldap-group cn=nice_users,ou=Group,dc=your,dc=domain
+  #       Satisfy any
+  #     </Limit>
+  dispatch :format_limits do
+    required_param 'Hash', :limits_hash
+  end
+
+  def format_limits(limits_hash)
+    limits = limits_hash.dup
+    limit_defaults = limits.delete('defaults') || [ 'GET' ]
+
+    limit_collection = {}
+
+   limits.keys.sort.each do |key|
+     begin
+        send("limit_#{key}",limits[key],limit_collection,limit_defaults)
+     rescue NoMethodError => e
+       fail("simp_apache::limits(): Error, '#{key}' not yet supported")
+     end
+    end
+
+    return collect_output(limit_collection)
+  end
+
+  def limit_hosts(opts,collection,limit_defaults)
+    opts.keys.sort.each do |k|
+      v = (opts[k] == 'defaults') ? limit_defaults : Array(opts[k])
+      v.each do |oper|
+        collection[oper] ||= []
+
+        collection[oper] << "Allow from #{k}"
+      end
+    end
+  end
+
+  #FIXME:  This is super confusing:
+  # 1) The 'users' key is used for LDAP users and a special
+  #    wild card.  In contrast, the 'ldap_groups' key is
+  #    used for LDAP groups.
+  # 2) There is no real support for non-LDAP users.
+  def limit_users(opts,collection,limit_defaults)
+    opts.keys.sort.each do |k|
+      v = (opts[k] == 'defaults') ? limit_defaults : Array(opts[k])
+
+      v.each do |oper|
+        collection[oper] ||= []
+
+        if k == 'valid-user'
+          collection[oper] << 'Require valid-user'
+        else
+          collection[oper] << "Require ldap-user #{k}"
+        end
+      end
+    end
+  end
+
+  def limit_ldap_groups(opts,collection,limit_defaults)
+    opts.keys.sort.each do |k|
+      v = (opts[k] == 'defaults') ? limit_defaults : Array(opts[k])
+
+      v.each do |oper|
+        collection[oper] ||= []
+
+        collection[oper] << "Require ldap-group #{k}"
+      end
+    end
+  end
+
+  def collect_output(collection)
+    output = []
+    collection.keys.sort.each do |k|
+      v = collection[k]
+      output << "<Limit #{k}>"
+      output << '  Order allow,deny'
+      output << "  #{v.sort.join("\n  ")}"
+      output << '  Require all denied'
+      output << '  Satisfy any'
+      output << '</Limit>'
+      output << ''
+    end
+
+    output.join("\n")
+  end
+end

--- a/lib/puppet/functions/simp_apache/munge_httpd_networks.rb
+++ b/lib/puppet/functions/simp_apache/munge_httpd_networks.rb
@@ -1,0 +1,37 @@
+# Provides a method by which an array of networks can be properly formatted
+# for an Apache Allow/Deny segment.
+#
+# This handles the case of 0.0.0.0/0, which Apache doesn't care for and
+# this function will convert to 'ALL'.
+#
+# The case where a <dotted quad address>/<dotted quatted netmask> is
+# passed is also handled since Apache doesn't care for these at all.
+Puppet::Functions.create_function(:'simp_apache::munge_httpd_networks') do
+
+  # @param networks Array of networks to be converted to Apache format
+  # @return [Array] Array of network s formated appropriately for Apache
+  dispatch :munge_httpd_networks do
+    required_param 'Array', :networks
+  end
+
+  def munge_httpd_networks(networks)
+    httpd_networks = []
+    networks.flatten.each do |x|
+      next if x.nil?
+
+      x.strip!
+      next if x.empty?
+
+      #TODO what about IPv6 addresses?
+      if x =~ /^0\.0\.0\.0/
+        httpd_networks << 'ALL'
+      elsif x =~ /\/\d{1,3}\./
+        httpd_networks << call_function('nets2cidr', x)
+      else
+        httpd_networks << x
+      end
+    end
+
+    httpd_networks.flatten
+  end
+end

--- a/lib/puppet/parser/functions/apache_auth.rb
+++ b/lib/puppet/parser/functions/apache_auth.rb
@@ -98,6 +98,8 @@ module Puppet::Parser::Functions
       content << "AuthUserFile #{opts['user_file']}"
     end
 
+    function_deprecation([:apache_auth, 'This method is deprecated, please use simp_apache::auth'])
+
     unless args.length == 1 and args.first.is_a?(Hash) then
       raise Puppet::ParseError, ("apache_auth(): You must supply exactly one Hash argument.")
     end

--- a/lib/puppet/parser/functions/apache_limits.rb
+++ b/lib/puppet/parser/functions/apache_limits.rb
@@ -137,6 +137,8 @@ module Puppet::Parser::Functions
       output.join("\n")
     end
 
+    function_deprecation([:apache_limits, 'This method is deprecated, please use simp_apache::limits'])
+
     unless args.count == 1 and args.first.is_a?(Hash) then
       raise Puppet::ParseError, ("apache_limits(): You must supply exactly one Hash argument.")
     end

--- a/lib/puppet/parser/functions/munge_httpd_networks.rb
+++ b/lib/puppet/parser/functions/munge_httpd_networks.rb
@@ -12,6 +12,8 @@ module Puppet::Parser::Functions
 
     ENDHEREDOC
 
+    function_deprecation([:munge_httpd_networks, 'This method is deprecated, please use simp_apache::munge_httpd_networks'])
+
     Puppet::Parser::Functions.autoloader.load(
       File.expand_path(File.dirname(__FILE__) + '/../../../../../simplib/lib/puppet/parser/nets2cidr.rb')
     )

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -68,7 +68,7 @@ class simp_apache::conf (
   include '::simp_apache'
 
   # Make sure the networks are all formatted correctly for Apache.
-  $l_allowroot = munge_httpd_networks($allowroot)
+  $l_allowroot = simp_apache::munge_httpd_networks($allowroot)
 
   file { [
     '/etc/httpd/conf',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_apache",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author": "SIMP Team",
   "summary": "configure SIMP apache & component sites (NOTE: legacy, conflicts with puppetlabs-apache)",
   "license": "Apache-2.0",

--- a/spec/functions/simp_apache/auth_spec.rb
+++ b/spec/functions/simp_apache/auth_spec.rb
@@ -1,0 +1,174 @@
+require 'spec_helper'
+
+describe 'simp_apache::auth' do
+  let(:file_auth_hash) {{
+    'file' => {
+      'enable'    => 'true',
+      'user_file' => '/etc/httpd/conf.d/test/.htdigest'
+    }
+  }}
+   
+  let(:full_ldap_auth_hash) {{
+    'ldap'    => {
+      'enable'      => 'true',
+      'url'         => ['ldap://server1','ldap://server2'],
+      'security'    => 'NONE',
+      'binddn'      => 'cn=happy,ou=People,dc=your,dc=domain',
+      'bindpw'      => 'birthday',
+      'search'      => 'ou=People,dc=your,dc=domain',
+      'posix_group' => 'true'
+    }
+  }}
+
+  let(:minimal_ldap_auth_hash) {{
+    'ldap'    => {
+      'enable'      => 'true',
+      'url'         => ['ldap://server1','ldap://server2'],
+      'search'      => 'ou=People,dc=your,dc=domain',
+      'posix_group' => 'false'
+    }
+  }}
+
+  context 'with valid input' do
+    it 'generates apache settings for enabled file auth method' do
+      expected_output = <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider file
+AuthUserFile /etc/httpd/conf.d/test/.htdigest
+EOM
+      is_expected.to run.with_params(file_auth_hash).and_return(expected_output.strip)
+    end
+
+    it 'generates apache settings for enabled ldap auth method with NONE security' do
+      expected_output = <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider ldap
+AuthLDAPUrl "ldap://server1 server2/ou=People,dc=your,dc=domain" NONE
+AuthLDAPBindDN "cn=happy,ou=People,dc=your,dc=domain"
+AuthLDAPBindPassword 'birthday'
+AuthLDAPGroupAttributeIsDN off
+AuthLDAPGroupAttribute memberUid
+EOM
+      is_expected.to run.with_params(full_ldap_auth_hash).and_return(expected_output.strip)
+    end
+
+    it 'generates apache settings for enabled ldap auth method with SSL security' do
+      input = full_ldap_auth_hash.dup
+      input['ldap']['security'] = 'SSL'
+      expected_output = <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider ldap
+AuthLDAPUrl "ldap://server1 server2/ou=People,dc=your,dc=domain" SSL
+AuthLDAPBindDN "cn=happy,ou=People,dc=your,dc=domain"
+AuthLDAPBindPassword 'birthday'
+AuthLDAPGroupAttributeIsDN off
+AuthLDAPGroupAttribute memberUid
+EOM
+      is_expected.to run.with_params(input).and_return(expected_output.strip)
+    end
+
+    it 'generates apache settings for enabled ldap auth method with TLS security' do
+      input = full_ldap_auth_hash.dup
+      input['ldap']['security'] = 'TLS'
+      expected_output = <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider ldap
+AuthLDAPUrl "ldap://server1 server2/ou=People,dc=your,dc=domain" TLS
+AuthLDAPBindDN "cn=happy,ou=People,dc=your,dc=domain"
+AuthLDAPBindPassword 'birthday'
+AuthLDAPGroupAttributeIsDN off
+AuthLDAPGroupAttribute memberUid
+EOM
+      is_expected.to run.with_params(input).and_return(expected_output.strip)
+    end
+
+    it 'generates apache settings for enabled ldap auth method with STARTTLS security' do
+      input = full_ldap_auth_hash.dup
+      input['ldap']['security'] = 'STARTTLS'
+      expected_output = <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider ldap
+AuthLDAPUrl "ldap://server1 server2/ou=People,dc=your,dc=domain" STARTTLS
+AuthLDAPBindDN "cn=happy,ou=People,dc=your,dc=domain"
+AuthLDAPBindPassword 'birthday'
+AuthLDAPGroupAttributeIsDN off
+AuthLDAPGroupAttribute memberUid
+EOM
+      is_expected.to run.with_params(input).and_return(expected_output.strip)
+    end
+
+    it 'generates apache settings for more than 1 enabled auth methods' do
+      input = file_auth_hash.dup.merge(minimal_ldap_auth_hash)
+      expected_output = <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider file ldap
+AuthUserFile /etc/httpd/conf.d/test/.htdigest
+AuthLDAPUrl "ldap://server1 server2/ou=People,dc=your,dc=domain"
+EOM
+      is_expected.to run.with_params(input).and_return(expected_output.strip)
+    end
+
+    it 'only generates apache settings for enabled auth methods' do
+      input = file_auth_hash.dup.merge(minimal_ldap_auth_hash)
+      input['ldap']['enable'] = false
+      expected_output = <<EOM
+AuthName "Please Authenticate"
+AuthType Basic
+AuthBasicProvider file
+AuthUserFile /etc/httpd/conf.d/test/.htdigest
+EOM
+      is_expected.to run.with_params(input).and_return(expected_output.strip)
+    end
+
+    it 'returns empty string when no enabled auth methods' do
+      input = file_auth_hash.dup.merge(minimal_ldap_auth_hash)
+      input['ldap']['enable'] = false
+      input['file']['enable'] = false
+      is_expected.to run.with_params(input).and_return('')
+    end
+  end
+
+  context 'with invalid input' do
+    it 'fails when unsupported auth method is requested'  do
+      input = {'dbm'=> {'enable' => true, 'user_file' => '/some/file'}}
+      is_expected.to run.with_params(input).and_raise_error(/'dbm' not yet supported/)
+    end
+
+    it 'fails when url option for ldap auth method is not present' do
+      input = minimal_ldap_auth_hash.dup
+      input['ldap'].delete('url')
+      is_expected.to run.with_params(input).and_raise_error(/missing option\(s\) 'url'/)
+    end
+
+    it 'fails when search option for ldap auth method is not present' do
+      input = minimal_ldap_auth_hash.dup
+      input['ldap'].delete('search')
+      is_expected.to run.with_params(input).and_raise_error(/missing option\(s\) 'search'/)
+    end
+
+    it 'fails when posix_group option for ldap auth method is not present' do
+      input = minimal_ldap_auth_hash.dup
+      input['ldap'].delete('posix_group')
+      is_expected.to run.with_params(input).and_raise_error(/missing option\(s\) 'posix_group'/)
+    end
+
+    it 'fails when security method for ldap auth method is invalid' do
+      input = full_ldap_auth_hash.dup
+      input['ldap']['security'] = 'OOPS'
+      is_expected.to run.with_params(input).and_raise_error(/Error, 'security'.* Got: 'OOPS'/)
+    end
+
+    it 'fails when not all required options for file auth method are present' do
+      input = file_auth_hash.dup
+      input['file'].delete('user_file')
+      is_expected.to run.with_params(input).and_raise_error(/missing option\(s\) 'user_file'/)
+    end
+  end
+end
+

--- a/spec/functions/simp_apache/limits_spec.rb
+++ b/spec/functions/simp_apache/limits_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+describe 'simp_apache::limits' do
+  let(:limits_hash) {{
+    'defaults' => [ 'GET', 'POST', 'PUT' ],
+    'hosts'  => {
+      '1.2.3.4'     => 'defaults',
+      '3.4.5.6'     => ['GET', 'POST'],
+      '10.1.2.0/24' => 'defaults'
+    },
+    'users'  => {
+      'bob'        => 'defaults',
+      'alice'      => ['GET','POST','PUT','DELETE']
+    },
+    'ldap_groups' => {
+      'cn=basic_users,ou=Group,dc=your,dc=domain' => 'defaults',
+      'cn=admin_users,ou=Group,dc=your,dc=domain' => ['GET','POST','PUT','DELETE']
+    }
+  }}
+   
+  context 'with valid input' do
+    it 'generates apache limits using defaults' do
+      expected_output = <<EOM
+<Limit DELETE>
+  Order allow,deny
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require all denied
+  Satisfy any
+</Limit>
+
+<Limit GET>
+  Order allow,deny
+  Allow from 1.2.3.4
+  Allow from 10.1.2.0/24
+  Allow from 3.4.5.6
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-group cn=basic_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require ldap-user bob
+  Require all denied
+  Satisfy any
+</Limit>
+
+<Limit POST>
+  Order allow,deny
+  Allow from 1.2.3.4
+  Allow from 10.1.2.0/24
+  Allow from 3.4.5.6
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-group cn=basic_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require ldap-user bob
+  Require all denied
+  Satisfy any
+</Limit>
+
+<Limit PUT>
+  Order allow,deny
+  Allow from 1.2.3.4
+  Allow from 10.1.2.0/24
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-group cn=basic_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require ldap-user bob
+  Require all denied
+  Satisfy any
+</Limit>
+EOM
+      is_expected.to run.with_params(limits_hash).and_return(expected_output)
+    end
+
+    it 'generates apache limits using the default for non-specified defaults key' do
+      limits_hash_no_defaults = limits_hash.dup
+      limits_hash_no_defaults.delete('defaults')
+      expected_output = <<EOM
+<Limit DELETE>
+  Order allow,deny
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require all denied
+  Satisfy any
+</Limit>
+
+<Limit GET>
+  Order allow,deny
+  Allow from 1.2.3.4
+  Allow from 10.1.2.0/24
+  Allow from 3.4.5.6
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-group cn=basic_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require ldap-user bob
+  Require all denied
+  Satisfy any
+</Limit>
+
+<Limit POST>
+  Order allow,deny
+  Allow from 3.4.5.6
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require all denied
+  Satisfy any
+</Limit>
+
+<Limit PUT>
+  Order allow,deny
+  Require ldap-group cn=admin_users,ou=Group,dc=your,dc=domain
+  Require ldap-user alice
+  Require all denied
+  Satisfy any
+</Limit>
+EOM
+      is_expected.to run.with_params(limits_hash_no_defaults).and_return(expected_output)
+    end
+
+    it 'generates apache wildcard user limits' do
+      valid_user_limits_hash = {'users' => {'valid-user' => 'GET' } }
+      expected_output = <<EOM
+<Limit GET>
+  Order allow,deny
+  Require valid-user
+  Require all denied
+  Satisfy any
+</Limit>
+EOM
+      is_expected.to run.with_params(valid_user_limits_hash).and_return(expected_output)
+    end
+
+    it 'returns empty string when no limits are specified' do
+      is_expected.to run.with_params({}).and_return('')
+    end
+  end
+
+  context 'with invalid input' do
+    it 'fails when unsupported limit is requested'  do
+      input = {'oops'=> {'user1' => 'defautls'}}
+      is_expected.to run.with_params(input).and_raise_error(/'oops' not yet supported/)
+    end
+  end
+end

--- a/spec/functions/simp_apache/munge_httpd_networks.rb
+++ b/spec/functions/simp_apache/munge_httpd_networks.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe 'simp_apache::munge_httpd_networks' do
+
+  context 'with valid input' do
+    it 'transforms IPv4 networks to apache settings format' do
+      input = ['0.0.0.0', '0.0.0.0/0', ' 1.2.3.4 ', '1.2.3.0/24', '1.2.0.0/255.255.0.0']
+      expected_output = ['ALL', 'ALL', '1.2.3.4', '1.2.3.0/24', '1.2.0.0/16']
+      is_expected.to run.with_params(input).and_return(expected_output)
+    end
+
+    it 'passes through hostnames to apache settings format' do
+      input = ['host1', 'host2']
+      is_expected.to run.with_params(input).and_return(input)
+    end
+
+    pending 'transforms IPV6 networks to apache settings format'
+  end
+
+  context 'with invalid input' do
+    # FIXME simplib net2cidr needs to be fixed
+    pending 'fails when transformation of an invalid IPv4 network is requested'  do
+      input = ['1.2.3.4/34', '1.2.3..']
+      is_expected.to run.with_params(input).and_raise_error(/is not a valid IP address/)
+    end
+
+    it 'fails when transformation of an invalid IPv4 network is requested'  do
+      input = ['1.2.3.4/255.']
+      is_expected.to run.with_params(input).and_raise_error(/is not a valid IP address/)
+    end
+
+    pending 'fails when transformation of an invalid IPV6 network is requested' 
+  end
+end


### PR DESCRIPTION
- Create namespaced, Puppet 4 versions of externally-used Puppet 3
  functions and mark the Puppet 3 functions as deprecated. They will
  be removed in a later release.
  - apache_auth should be replaced with simp_apache::auth
  - apache_limits should be replaced with simp_apache::limits
  - munge_httpd_networks should be replaced with simp_apache::munge_httpd_network
- Added spec tests

SIMP-3347 #close